### PR TITLE
Manter `esp` no nível de item e reaproveitar valor do snapshot anterior

### DIFF
--- a/v2/update_json.py
+++ b/v2/update_json.py
@@ -58,13 +58,15 @@ if os.path.exists(all_device_firmware_old):
     for new_item in data:
         for old_item in old_data:
             if new_item['_id'] == old_item['_id']:
+                if 'esp' in old_item:
+                    new_item['esp'] = old_item['esp']
                 for new_version in new_item['versions']:
                     new_version.pop('change_log', None)
                     new_version.pop('published', None)
                     for old_version in old_item['versions']:
                         if new_version['version'] == old_version['version']:
                             if new_version['file'] == old_version['file']:
-                                fields_to_copy = ['Fs', 'as', 'ss', 'so', 's', 'nb', 'fs', 'fo', 'f', 'fs2', 'fo2', 'f2', 'esp']
+                                fields_to_copy = ['Fs', 'as', 'ss', 'so', 's', 'nb', 'fs', 'fo', 'f', 'fs2', 'fo2', 'f2']
                                 for field in fields_to_copy:
                                     if field in old_version:
                                         new_version[field] = old_version[field]


### PR DESCRIPTION
### Motivation
- O campo `esp` precisa permanecer no nível de `item` no JSON base e não em `version`.
- Reprocessamentos longos de firmwares `stickc` ocorriam porque `item['esp']` não era reaproveitado entre execuções, disparando checagens desnecessárias.

### Description
- Reverti a lógica para checar e gravar `esp` no nível do item com `if item.get('category') == 'stickc' and 'esp' not in item:` e escrever em `item['esp']` quando detectado.
- Ao mesclar com o snapshot anterior (`all_device_firmware.old.json`), agora copio `old_item['esp']` para `new_item['esp']` quando presente para evitar reprocessamento.
- Removi `'esp'` da lista de campos copiados por versão para manter consistência de níveis de dados.
- As alterações foram feitas em `v2/update_json.py`.

### Testing
- Executei `python -m py_compile v2/update_json.py` e a compilação foi bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866fab42e8832cab39440f17bc6ebe)