### PR TITLE
Fix unescaped quote breaking update_firmware.json

### DIFF
--- a/3rd/update_firmware.json
+++ b/3rd/update_firmware.json
@@ -596,7 +596,7 @@
         "author": "C5Lab",
         "cover": "https://github.com/user-attachments/assets/85c42338-14af-4657-bb06-fee8f34061de",
         "github": "https://github.com/C5Lab/pancake",
-        "description": "Pancake is a portable, touchscreen-driven WiFi security toolkit running on the Waveshare ESP32-C5-WIFI6-KIT. Inspired by Pwnagotchi-style devices, it combines a rich set of offensive and defensive WiFi tools with BLE scanning, GPS wardriving, and a beautiful Material-style dark UI — all packed into a handheld form factor with a 3.5" capacitive touch display.",
+        "description": "Pancake is a portable, touchscreen-driven WiFi security toolkit running on the Waveshare ESP32-C5-WIFI6-KIT. Inspired by Pwnagotchi-style devices, it combines a rich set of offensive and defensive WiFi tools with BLE scanning, GPS wardriving, and a beautiful Material-style dark UI — all packed into a handheld form factor with a 3.5\" capacitive touch display.",
         "fid_prefix": "Pancake",
         "devices": [
             {


### PR DESCRIPTION
`3rd/update_firmware.json` is currently invalid JSON, which silently breaks the updater for everything.

The Pancake entry's description has an unescaped `"` in `3.5"` (line 599) that ends the string early. `load_firmware_configs()` catches the resulting JSONDecodeError and returns `[]`, so the run skips every firmware, not just Pancake — nothing new gets picked up for anyone.

Noticed it because our WADAMESH releases stopped showing up in Launcher. Escaped the quote and it parses fine again, that's the only line changed.
